### PR TITLE
Adding cloudWatch metrics sidecar to ingress gateway envoy

### DIFF
--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
@@ -581,6 +581,37 @@ Resources:
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualGateway/colorgateway-vg'
             - Name: 'APPMESH_XDS_ENDPOINT'
               Value: !Sub '${AppMeshXdsEndpoint}'
+            - Name: 'ENABLE_ENVOY_STATS_TAGS'
+              Value: '1'
+            - Name: 'ENABLE_ENVOY_DOG_STATSD'
+              Value: '1'
+            - Name: 'STATSD_PORT'
+              Value: '8125'
+
+        - Name: 'cw-agent'
+          Image: 'amazon/cloudwatch-agent'
+          Essential: true
+          PortMappings:
+            - ContainerPort: 8125
+              Protocol: 'udp'
+          Environment:
+            - Name: CW_CONFIG_CONTENT
+              Value:
+                Fn::Sub:
+                  - '{ "logs": { "metrics_collected": {"emf": {} }}, "metrics": { "metrics_collected": { "statsd": {}}, "namespace": "${MetricNamespace}"}}'
+                  - MetricNamespace:
+                      Fn::Join:
+                      - '/'
+                      - - !Ref EnvironmentName
+                        - gateway-envoy
+                        - StatsD
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group:
+                Fn::ImportValue: !Sub "${EnvironmentName}:ECSServiceLogGroup"
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'gateway-cw-agent'
 
   ColorGatewayService:
     Type: 'AWS::ECS::Service'


### PR DESCRIPTION
*Description of changes:*

Offloading Gateway Envoy stats to CloudWatch metrics sidecar

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
